### PR TITLE
1 support numbers in parsing json

### DIFF
--- a/M5StackThermohygrometer/AWSSettings.cpp
+++ b/M5StackThermohygrometer/AWSSettings.cpp
@@ -14,7 +14,7 @@ const std::string kRootCaPathKey = "rootCaPath";
 const std::string kDeviceCertPathKey = "deviceCertPath";
 const std::string kPrivateKeyPathKey = "privateKeyPath";
 
-AWSSettings::AWSSettings(std::string client_id, std::string endpoint, std::string port, std::string root_ca, std::string device_certificate, std::string private_key, std::string topic)
+AWSSettings::AWSSettings(std::string client_id, std::string endpoint, int port, std::string root_ca, std::string device_certificate, std::string private_key, std::string topic)
 {
     this->client_id = client_id;
     this->endpoint = endpoint;
@@ -36,8 +36,8 @@ AWSSettings* AWSSettings::FromString(std::string json)
     std::string client_id = client_id_element->data;
     JsonStringElement* endpoint_element = static_cast<JsonStringElement*>(aws_settings_map[kEndpointKey]);
     std::string endpoint = endpoint_element->data;
-    JsonStringElement* port_element = static_cast<JsonStringElement*>(aws_settings_map[kPortKey]);
-    std::string port = port_element->data;
+    JsonNumberElement* port_element = static_cast<JsonNumberElement*>(aws_settings_map[kPortKey]);
+    int port = port_element->data;
     JsonStringElement* topic_element = static_cast<JsonStringElement*>(aws_settings_map[kTopicKey]);
     std::string topic = topic_element->data;
     JsonStringElement* root_ca_path_element = static_cast<JsonStringElement*>(aws_settings_map[kRootCaPathKey]);

--- a/M5StackThermohygrometer/AWSSettings.cpp
+++ b/M5StackThermohygrometer/AWSSettings.cpp
@@ -31,13 +31,20 @@ AWSSettings::~AWSSettings()
 
 AWSSettings* AWSSettings::FromString(std::string json)
 {
-    std::map<std::string, std::string> aws_settings_map = JsonHandler::Parse(json);
-    std::string client_id = aws_settings_map[kClientIdKey];
-    std::string endpoint = aws_settings_map[kEndpointKey];
-    std::string port = aws_settings_map[kPortKey];
-    std::string topic = aws_settings_map[kTopicKey];
-    std::string root_ca = SDCardController::ReadFileFromSDCard(kSDCardRootPath + kAwsDocsFilePath + aws_settings_map[kRootCaPathKey]);
-    std::string device_certificate = SDCardController::ReadFileFromSDCard(kSDCardRootPath + kAwsDocsFilePath + aws_settings_map[kDeviceCertPathKey]);
-    std::string private_key = SDCardController::ReadFileFromSDCard(kSDCardRootPath + kAwsDocsFilePath + aws_settings_map[kPrivateKeyPathKey]);
+    std::map<std::string, JsonElement*> aws_settings_map = JsonHandler::Parse(json);
+    JsonStringElement* client_id_element = static_cast<JsonStringElement*>(aws_settings_map[kClientIdKey]);
+    std::string client_id = client_id_element->data;
+    JsonStringElement* endpoint_element = static_cast<JsonStringElement*>(aws_settings_map[kEndpointKey]);
+    std::string endpoint = endpoint_element->data;
+    JsonStringElement* port_element = static_cast<JsonStringElement*>(aws_settings_map[kPortKey]);
+    std::string port = port_element->data;
+    JsonStringElement* topic_element = static_cast<JsonStringElement*>(aws_settings_map[kTopicKey]);
+    std::string topic = topic_element->data;
+    JsonStringElement* root_ca_path_element = static_cast<JsonStringElement*>(aws_settings_map[kRootCaPathKey]);
+    JsonStringElement* device_cert_path_element = static_cast<JsonStringElement*>(aws_settings_map[kDeviceCertPathKey]);
+    JsonStringElement* private_key_path_element = static_cast<JsonStringElement*>(aws_settings_map[kPrivateKeyPathKey]);
+    std::string root_ca = SDCardController::ReadFileFromSDCard(kSDCardRootPath + kAwsDocsFilePath + root_ca_path_element->data);
+    std::string device_certificate = SDCardController::ReadFileFromSDCard(kSDCardRootPath + kAwsDocsFilePath + device_cert_path_element->data);
+    std::string private_key = SDCardController::ReadFileFromSDCard(kSDCardRootPath + kAwsDocsFilePath + private_key_path_element->data);
     return new AWSSettings(client_id, endpoint, port, root_ca, device_certificate, private_key, topic);
 }

--- a/M5StackThermohygrometer/AWSSettings.hpp
+++ b/M5StackThermohygrometer/AWSSettings.hpp
@@ -5,7 +5,7 @@
 class AWSSettings
 {
 public:
-	AWSSettings(std::string client_id, std::string endpoint, std::string port, std::string root_ca, std::string device_certificate, std::string private_key, std::string topic);
+	AWSSettings(std::string client_id, std::string endpoint, int port, std::string root_ca, std::string device_certificate, std::string private_key, std::string topic);
 	~AWSSettings();
 
 public:
@@ -14,7 +14,7 @@ public:
 public:
 	std::string client_id;
 	std::string endpoint;
-	std::string port;
+	int port;
 	std::string root_ca;
 	std::string device_certificate;
 	std::string private_key;

--- a/M5StackThermohygrometer/CommunicationClientImpl.cpp
+++ b/M5StackThermohygrometer/CommunicationClientImpl.cpp
@@ -105,7 +105,7 @@ bool CommunicationClientImpl::SetUpMqttClient()
 	http_client_->setCACert(settings_->aws_settings->root_ca.c_str());
 	http_client_->setCertificate(settings_->aws_settings->device_certificate.c_str());
 	http_client_->setPrivateKey(settings_->aws_settings->private_key.c_str());
-	mqtt_client_->setServer(settings_->aws_settings->endpoint.c_str(), atoi(settings_->aws_settings->port.c_str()));
+	mqtt_client_->setServer(settings_->aws_settings->endpoint.c_str(), settings_->aws_settings->port);
 	mqtt_client_->setCallback(&MqttCallback);
 }
 

--- a/M5StackThermohygrometer/JsonElement.cpp
+++ b/M5StackThermohygrometer/JsonElement.cpp
@@ -1,0 +1,25 @@
+#include "JsonElement.hpp"
+
+JsonElement::JsonElement(JsonElementType type) : type(type)
+{
+}
+
+JsonElement::~JsonElement()
+{
+}
+
+JsonNumberElement::JsonNumberElement(int data) : JsonElement(JsonElementType::kNumber), data(data)
+{
+}
+
+JsonNumberElement::~JsonNumberElement()
+{
+}
+
+JsonStringElement::JsonStringElement(std::string data) : JsonElement(JsonElementType::kString), data(data)
+{
+}
+
+JsonStringElement::~JsonStringElement()
+{
+}

--- a/M5StackThermohygrometer/JsonElement.hpp
+++ b/M5StackThermohygrometer/JsonElement.hpp
@@ -22,7 +22,7 @@ public:
 
 public:
     int data;
-}
+};
 
 class JsonStringElement : public JsonElement
 {
@@ -32,4 +32,4 @@ public:
 
 public:
     std::string data;
-}
+};

--- a/M5StackThermohygrometer/JsonElement.hpp
+++ b/M5StackThermohygrometer/JsonElement.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+
+#include "JsonElementType.hpp"
+
+class JsonElement
+{
+public:
+    JsonElement(JsonElementType type);
+    virtual ~JsonElement();
+
+public:
+    JsonElementType type;
+};
+
+class JsonNumberElement : public JsonElement
+{
+public:
+    JsonNumberElement(int data);
+    ~JsonNumberElement();
+
+public:
+    int data;
+}
+
+class JsonStringElement : public JsonElement
+{
+public:
+    JsonStringElement(std::string data);
+    ~JsonStringElement();
+
+public:
+    std::string data;
+}

--- a/M5StackThermohygrometer/JsonElementType.hpp
+++ b/M5StackThermohygrometer/JsonElementType.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+enum class JsonElementType
+{
+    kNumber,
+    kString
+};

--- a/M5StackThermohygrometer/JsonHandler.cpp
+++ b/M5StackThermohygrometer/JsonHandler.cpp
@@ -40,7 +40,7 @@ std::string JsonHandler::Serialize(std::map<std::string, std::string> jsonMap)
 	return json;
 }
 
-std::map<std::string, std::string> JsonHandler::Parse(std::string raw)
+std::map<std::string, JsonElement*> JsonHandler::Parse(std::string raw)
 {
 	ConsoleLogger::Log(new LogData(LogLevel::kTrace, kJsonHandler, kParse, "in: raw=" + raw));
 	if (raw.empty())
@@ -49,7 +49,7 @@ std::map<std::string, std::string> JsonHandler::Parse(std::string raw)
 		throw std::invalid_argument("json string has no characters");
 	}
 
-	std::map<std::string, std::string> map;
+	std::map<std::string, JsonElement*> map;
 
 	int count = 0;
 	count = SkipBlankAndNewLineCharacters(raw, count);
@@ -185,5 +185,5 @@ JsonHandler::sKeyValuePairResult JsonHandler::ExtractKeyValuePair(std::string co
 	ConsoleLogger::Log(new LogData(LogLevel::kTrace, kJsonHandler, kExtractKeyValuePair,
 		"out: key=" + std::string(key) + ",value=" + value + ",count=" + std::string(String(index + 1).c_str())
 	));
-	return sKeyValuePairResult{ std::string(key), std::string(value), index + 1 };
+	return sKeyValuePairResult{ std::string(key), new JsonStringElement(value), index + 1 };
 }

--- a/M5StackThermohygrometer/JsonHandler.cpp
+++ b/M5StackThermohygrometer/JsonHandler.cpp
@@ -1,5 +1,6 @@
 #include "JsonHandler.hpp"
 
+#include <cstdio>
 #include <stdexcept>
 
 #include <M5Stack.h>
@@ -157,33 +158,60 @@ JsonHandler::sKeyValuePairResult JsonHandler::ExtractKeyValuePair(std::string co
 		throw std::invalid_argument("key and value should be divided with colon ( : )");
 	}
 	index = SkipIfBlankCharacters(content, index);
-	if (content[index++] != kQuotationMark)
+	if (content[index] != kQuotationMark)
 	{
-		ConsoleLogger::Log(new LogData(LogLevel::kError, kJsonHandler, kExtractKeyValuePair,
-			"Value does not start with quotation ( \" ): count=" + std::string(String(index).c_str())
+		char value[100];
+		int value_index = 0;
+		while (true)
+		{
+			if (content[index] == kEndOfString)
+			{
+				ConsoleLogger::Log(new LogData(LogLevel::kError, kJsonHandler, kExtractKeyValuePair,
+					"Json body incorrectly comes to the end: count=" + std::string(String(index).c_str())
+				));
+				throw std::invalid_argument("incorrectly comes to the end of json string");
+			}
+			if (content[index] == kComma || content[index] == kSpace)
+			{
+				value[value_index] = kEndOfString;
+				break;
+			}
+			if (content[index] < 0x30 || 0x39 < content[index])
+			{
+				ConsoleLogger::Log(new LogData(LogLevel::kError, kJsonHandler, kExtractKeyValuePair,
+					"invalid number has been found: count=" + std::string(String(index).c_str())
+				));
+				throw std::invalid_argument("invalid number has been found");
+			}
+			value[value_index++] = content[index++];
+		}
+		int int_value = atoi(value);
+		return sKeyValuePairResult{ std::string(key), new JsonNumberElement(int_value), index };
+	}
+	else
+	{
+		char value[100];
+		int value_index = 0;
+		index++;
+		while (true)
+		{
+			if (content[index] == kEndOfString)
+			{
+				ConsoleLogger::Log(new LogData(LogLevel::kError, kJsonHandler, kExtractKeyValuePair,
+					"Json body incorrectly comes to the end: count=" + std::string(String(index).c_str())
+				));
+				throw std::invalid_argument("incorrectly comes to the end of json string");
+			}
+			if (content[index] == kQuotationMark)
+			{
+				value[value_index] = kEndOfString;
+				break;
+			}
+			value[value_index++] = content[index++];
+		}
+		ConsoleLogger::Log(new LogData(LogLevel::kTrace, kJsonHandler, kExtractKeyValuePair,
+			"out: key=" + std::string(key) + ",value=" + value + ",count=" + std::string(String(index + 1).c_str())
 		));
-		throw std::invalid_argument("value does not start with open quotation ( \" )");
-	}
-	char value[100];
-	int value_index = 0;
-	while (true)
-	{
-		if (content[index] == kEndOfString)
-		{
-			ConsoleLogger::Log(new LogData(LogLevel::kError, kJsonHandler, kExtractKeyValuePair,
-				"Json body incorrectly comes to the end: count=" + std::string(String(index).c_str())
-			));
-			throw std::invalid_argument("incorrectly comes to the end of json string");
-		}
-		if (content[index] == kQuotationMark)
-		{
-			value[value_index] = kEndOfString;
-			break;
-		}
-		value[value_index++] = content[index++];
-	}
-	ConsoleLogger::Log(new LogData(LogLevel::kTrace, kJsonHandler, kExtractKeyValuePair,
-		"out: key=" + std::string(key) + ",value=" + value + ",count=" + std::string(String(index + 1).c_str())
-	));
-	return sKeyValuePairResult{ std::string(key), new JsonStringElement(value), index + 1 };
+		return sKeyValuePairResult{ std::string(key), new JsonStringElement(value), index + 1 };
+	}	
 }

--- a/M5StackThermohygrometer/JsonHandler.hpp
+++ b/M5StackThermohygrometer/JsonHandler.hpp
@@ -3,19 +3,21 @@
 #include <map>
 #include <string>
 
+#include "JsonElement.hpp"
+
 class JsonHandler
 {
 private:
 	typedef struct
 	{
 		std::string key;
-		std::string value;
+		JsonElement* value;
 		int index;
 	} sKeyValuePairResult;
 
 public:
 	static std::string Serialize(std::map<std::string, std::string> jsonMap);
-	static std::map<std::string, std::string> Parse(std::string raw);
+	static std::map<std::string, JsonElement*> Parse(std::string raw);
 
 private:
 	static int SkipIfBlankCharacters(std::string content, int index);

--- a/M5StackThermohygrometer/WiFiSettings.cpp
+++ b/M5StackThermohygrometer/WiFiSettings.cpp
@@ -14,8 +14,10 @@ WiFiSettings::WiFiSettings(std::string ssid, std::string password)
 }
 
 WiFiSettings* WiFiSettings::FromString(std::string json) {
-    std::map<std::string, std::string> wifi_settings_map = JsonHandler::Parse(json);
-    std::string ssid = wifi_settings_map[kSsidKey];
-    std::string password = wifi_settings_map[kPasswordKey];
+    std::map<std::string, JsonElement*> wifi_settings_map = JsonHandler::Parse(json);
+    JsonStringElement* ssid_element = static_cast<JsonStringElement*>(wifi_settings_map[kSsidKey]);
+    std::string ssid = ssid_element->data;
+    JsonStringElement* password_element = static_cast<JsonStringElement*>(wifi_settings_map[kPasswordKey]);
+    std::string password = password_element->data;
     return new WiFiSettings(ssid, password);
 }


### PR DESCRIPTION
JSONパース処理で数値データを扱えるように処理を修正。
併せて、JSONのvalueの値をstring型ではなく、JsonElement*型に修正。
取得したい値の種類に合わせて子クラスにダウンキャストすることで数値または文字列のデータを取得できるようにしている。
現状数値データを使用しているのはAWSへの接続時に使用しているポート番号のみ。