### PR TITLE
10 modify the way of creating task manager instance

### DIFF
--- a/M5StackThermohygrometerApp/lib/TaskManager/TaskManager.cpp
+++ b/M5StackThermohygrometerApp/lib/TaskManager/TaskManager.cpp
@@ -8,16 +8,6 @@ static const int kMeasureTaskCore = 0;
 static const int kMeasureTaskPriority = 0;
 static const std::string kMeasureTaskToken = "MeasureTask";
 
-TaskManager* TaskManager::GetInstance()
-{
-    static TaskManager* instance = nullptr;
-    if (!instance)
-    {
-        instance = new TaskManager();
-    }
-    return instance;
-}
-
 TaskManager::TaskManager()
 {
 }

--- a/M5StackThermohygrometerApp/lib/TaskManager/TaskManager.hpp
+++ b/M5StackThermohygrometerApp/lib/TaskManager/TaskManager.hpp
@@ -8,9 +8,6 @@
 class TaskManager
 {
 public:
-    static TaskManager* GetInstance();
-
-private:
     TaskManager();
     ~TaskManager();
 

--- a/M5StackThermohygrometerApp/src/main.cpp
+++ b/M5StackThermohygrometerApp/src/main.cpp
@@ -7,7 +7,7 @@
 #include <ViewController.hpp>
 
 GUIManager* gui_manager = new GUIManager(new ViewController());
-TaskManager* task_manager = TaskManager::GetInstance();
+TaskManager* task_manager = new TaskManager();
 
 void setup()
 {


### PR DESCRIPTION
TaskManagerをsingletonでインスタンスを生成する実装にしていたが、現状複数個所から参照されるようには実装されていないため、通常のインスタンス生成の方法をとるように修正。
影響範囲のmain内のコードも併せて修正。