### PR TITLE
9 implement cursor movement

### DIFF
--- a/M5StackThermohygrometerApp/lib/GUIManager/ResultListViewState.cpp
+++ b/M5StackThermohygrometerApp/lib/GUIManager/ResultListViewState.cpp
@@ -32,6 +32,7 @@ void ResultListViewState::DoRightButtonAction(GUIContext* context)
 {
 	ConsoleLogger::Log(new LogData(LogLevel::kInfo, kResultListViewState, kDoRightButtonAction, "in"));
 	context->ScrollDown();
+	context->DisplayResultList();
 }
 
 void ResultListViewState::DoMiddleButtonAction(GUIContext* context)
@@ -44,4 +45,5 @@ void ResultListViewState::DoLeftButtonAction(GUIContext* context)
 {
 	ConsoleLogger::Log(new LogData(LogLevel::kInfo, kResultListViewState, kDoLeftButtonAction, "in"));
 	context->ScrollUp();
+	context->DisplayResultList();
 }

--- a/M5StackThermohygrometerApp/lib/GUIManager/ViewController.cpp
+++ b/M5StackThermohygrometerApp/lib/GUIManager/ViewController.cpp
@@ -112,15 +112,17 @@ void ViewController::DisplayResultList()
         start = current_start_index_;
         end = (start + kMaxDisplayNums < length) ? start + kMaxDisplayNums : length;
     }
-    else if (current_cursor_ < current_start_index_)
+    else
     {
-        end = (current_cursor_ + kMaxDisplayNums <= length) ? current_cursor_ + kMaxDisplayNums : length;
-        start = (end - kMaxDisplayNums >= 0) ? end - kMaxDisplayNums : 0;
-    }
-    else if (current_end_index_ <= current_cursor_)
-    {
-        end = current_cursor_ + 1;
-        start = (end - kMaxDisplayNums >= 0) ? end - kMaxDisplayNums : 0;
+        if (current_cursor_ < current_start_index_)
+        {
+            end = (current_cursor_ + kMaxDisplayNums < length) ? current_cursor_ + kMaxDisplayNums : length;
+        }
+        else if (current_end_index_ <= current_cursor_)
+        {
+            end = current_cursor_ + 1;
+        }
+        start = (end - kMaxDisplayNums > 0) ? end - kMaxDisplayNums : 0;
     }
     for (int i = 0; i < start; i++) itr++;
     for (int i = start; i < end; i++)

--- a/M5StackThermohygrometerApp/lib/GUIManager/ViewController.cpp
+++ b/M5StackThermohygrometerApp/lib/GUIManager/ViewController.cpp
@@ -56,7 +56,8 @@ void ViewController::ChangeState(ViewType type)
     state_ = nullptr;
     current_cursor_ = 0;
     current_start_index_ = 0;
-    current_end_index_ = 0;
+    int size = result_manager_->GetResults().size();
+    current_end_index_ = size < kMaxDisplayNums ? size : kMaxDisplayNums;
     state_ = ViewState::GetInstance(type);
     state_->Initialize(this);
     ConsoleLogger::Log(new LogData(LogLevel::kTrace, kViewController, kChangeState, "out"));

--- a/M5StackThermohygrometerApp/lib/GUIManager/ViewController.cpp
+++ b/M5StackThermohygrometerApp/lib/GUIManager/ViewController.cpp
@@ -65,13 +65,13 @@ void ViewController::ChangeState(ViewType type)
 void ViewController::ScrollUp()
 {
     ConsoleLogger::Log(new LogData(LogLevel::kTrace, kViewController, kScrollUp, "in"));
-    if (current_cursor_ > 1) current_cursor_--;
+    if (current_cursor_ > 0) current_cursor_--;
 }
 
 void ViewController::ScrollDown()
 {
     ConsoleLogger::Log(new LogData(LogLevel::kTrace, kViewController, kScrollDown, "in"));
-    if (current_cursor_ < result_manager_->GetResults().size() - 2) current_cursor_++;
+    if (current_cursor_ < result_manager_->GetResults().size() - 1) current_cursor_++;
 }
 
 void ViewController::DisplayLatestResult()

--- a/M5StackThermohygrometerApp/lib/GUIManager/ViewController.cpp
+++ b/M5StackThermohygrometerApp/lib/GUIManager/ViewController.cpp
@@ -124,8 +124,10 @@ void ViewController::DisplayResultList()
     for (int i = 0; i < start; i++) itr++;
     for (int i = start; i < end; i++)
     {
+        if (i == current_cursor_) M5.Lcd.setTextColor(YELLOW);
         MeasurementResult* result = *itr;
         M5.Lcd.printf("[%s] %5.2f %5.2f\n", result->time.c_str(), result->thermohygro_data->temperature, result->thermohygro_data->humidity);
+        M5.Lcd.setTextColor(WHITE);
         itr++;
     }
     current_start_index_ = start;

--- a/M5StackThermohygrometerApp/lib/GUIManager/ViewController.cpp
+++ b/M5StackThermohygrometerApp/lib/GUIManager/ViewController.cpp
@@ -54,10 +54,14 @@ void ViewController::ChangeState(ViewType type)
     state_->Finalize(this);
     delete state_;
     state_ = nullptr;
+
+    // カーソル位置と表示データ範囲の初期化
+    // 表示データ範囲の初期値は一番古いデータから5つないし最新データまで
     current_cursor_ = 0;
     current_start_index_ = 0;
     int size = result_manager_->GetResults().size();
     current_end_index_ = size < kMaxDisplayNums ? size : kMaxDisplayNums;
+
     state_ = ViewState::GetInstance(type);
     state_->Initialize(this);
     ConsoleLogger::Log(new LogData(LogLevel::kTrace, kViewController, kChangeState, "out"));
@@ -66,12 +70,14 @@ void ViewController::ChangeState(ViewType type)
 void ViewController::ScrollUp()
 {
     ConsoleLogger::Log(new LogData(LogLevel::kTrace, kViewController, kScrollUp, "in"));
+    // カーソルがすでに一番古いデータを指している場合は何もしない
     if (current_cursor_ > 0) current_cursor_--;
 }
 
 void ViewController::ScrollDown()
 {
     ConsoleLogger::Log(new LogData(LogLevel::kTrace, kViewController, kScrollDown, "in"));
+    // カーソルがすでに最新データをさしている場合は何もしない
     if (current_cursor_ < result_manager_->GetResults().size() - 1) current_cursor_++;
 }
 
@@ -102,11 +108,16 @@ void ViewController::DisplayResultList()
     M5.Lcd.setTextSize(kListDisplaySize);
     M5.Lcd.setTextColor(WHITE);
     M5.Lcd.setCursor(0, 0);
+
+    // 測定結果がない場合はここで終了
     if (results.empty()) return;
+
+    // 表示データ範囲のアップデート
     auto itr = results.begin();
     int length = results.size();
     int start = 0;
     int end = 0;
+    // カーソルが直前の表示データ範囲におさまっている場合
     if (current_start_index_ <= current_cursor_ && current_cursor_ < current_end_index_)
     {
         start = current_start_index_;
@@ -114,19 +125,24 @@ void ViewController::DisplayResultList()
     }
     else
     {
+        // カーソルが直前の表示データ範囲よりも古いものを指している場合
         if (current_cursor_ < current_start_index_)
         {
             end = (current_cursor_ + kMaxDisplayNums < length) ? current_cursor_ + kMaxDisplayNums : length;
         }
+        // カーソルが直前の表示データ範囲よりも新しいものをさしている場合
         else if (current_end_index_ <= current_cursor_)
         {
             end = current_cursor_ + 1;
         }
         start = (end - kMaxDisplayNums > 0) ? end - kMaxDisplayNums : 0;
     }
+
+    // 表示データ範囲までスキップ
     for (int i = 0; i < start; i++) itr++;
     for (int i = start; i < end; i++)
     {
+        // カーソル位置のデータは黄色で表示。それ以外は白色で表示。
         if (i == current_cursor_) M5.Lcd.setTextColor(YELLOW);
         MeasurementResult* result = *itr;
         M5.Lcd.printf("[%s] %5.2f %5.2f\n", result->time.c_str(), result->thermohygro_data->temperature, result->thermohygro_data->humidity);

--- a/M5StackThermohygrometerApp/lib/GUIManager/ViewController.hpp
+++ b/M5StackThermohygrometerApp/lib/GUIManager/ViewController.hpp
@@ -24,4 +24,6 @@ private:
     ViewState* state_;
     MeasurementResultManager* result_manager_;
     int current_cursor_;
+    int current_start_index_;
+    int current_end_index_;
 };


### PR DESCRIPTION
温湿度データのリスト表示時のカーソル移動処理を実装。
影響範囲はリスト表示処理を呼び出しているResultListViewStateクラスと実処理を行うViewControllerクラスのみ。
カーソルが先頭または末尾にある時は逆側の末端へのカーソル移動はせず、そのままの位置にとどまるように実装している。