### PR TITLE
support non-new-line-code ending after the last json item

### DIFF
--- a/M5StackThermohygrometerApp/lib/JsonHandler/src/JsonHandler.cpp
+++ b/M5StackThermohygrometerApp/lib/JsonHandler/src/JsonHandler.cpp
@@ -67,10 +67,11 @@ std::map<std::string, JsonElement*> JsonHandler::Parse(std::string raw)
 		sKeyValuePairResult result = ExtractKeyValuePair(raw, count);
 		map.insert(std::make_pair(result.key, result.value));
 		count = result.index;
-		if (raw[count++] != kComma)
+		if (raw[count] != kComma)
 		{
 			break;
 		}
+		count++;
 	}
 	count = SkipBlankAndNewLineCharacters(raw, count);
 	if (raw[count] != kCloseBracket)


### PR DESCRIPTION
JSONの最後の要素の直後に改行文字がない場合も正常にパースできるように処理を修正。
JSONの仕様として改行文字を期待することはおかしいので、全要素の間の改行文字がない場合も正常にパースされることを確認した。