### PR TITLE
#20 add unit test codes for settings lib

### DIFF
--- a/M5StackThermohygrometerApp/lib/CommunicationClient/src/CommunicationClientImpl.cpp
+++ b/M5StackThermohygrometerApp/lib/CommunicationClient/src/CommunicationClientImpl.cpp
@@ -6,12 +6,15 @@
 #include <ConsoleLogger.hpp>
 #include <LogConstants.hpp>
 #include <SettingsProvider.hpp>
+#include <SDCardController.hpp>
 
 static const uint16_t kKeepAliveSecs = 90;
 
 CommunicationClientImpl::CommunicationClientImpl()
 {
-	settings_ = SettingsProvider::Of();
+	SDCardController* sd_card_controller = new SDCardController();
+	settings_ = SettingsProvider::Of(sd_card_controller);
+	delete sd_card_controller;
 	http_client_ = new WiFiClientSecure();
 	mqtt_client_ = new PubSubClient();
 	Prepare();

--- a/M5StackThermohygrometerApp/lib/SDCardController/src/SDCardController.hpp
+++ b/M5StackThermohygrometerApp/lib/SDCardController/src/SDCardController.hpp
@@ -8,5 +8,5 @@ private:
 	static const int kMaxReadSize = 2048;
 
 public:
-	static std::string ReadFileFromSDCard(std::string file_name);
+	virtual std::string ReadFileFromSDCard(std::string file_name);
 };

--- a/M5StackThermohygrometerApp/lib/Settings/src/AWSSettings.cpp
+++ b/M5StackThermohygrometerApp/lib/Settings/src/AWSSettings.cpp
@@ -4,7 +4,6 @@
 
 #include <JsonHandler.hpp>
 #include <SDCardConstants.hpp>
-#include <SDCardController.hpp>
 
 const std::string kClientIdKey = "clientId";
 const std::string kEndpointKey = "endpoint";
@@ -29,7 +28,7 @@ AWSSettings::~AWSSettings()
 {
 }
 
-AWSSettings* AWSSettings::FromString(std::string json)
+AWSSettings* AWSSettings::FromString(std::string json, SDCardController* sd_card_controller)
 {
     std::map<std::string, JsonElement*> aws_settings_map = JsonHandler::Parse(json);
     JsonStringElement* client_id_element = static_cast<JsonStringElement*>(aws_settings_map[kClientIdKey]);
@@ -43,8 +42,8 @@ AWSSettings* AWSSettings::FromString(std::string json)
     JsonStringElement* root_ca_path_element = static_cast<JsonStringElement*>(aws_settings_map[kRootCaPathKey]);
     JsonStringElement* device_cert_path_element = static_cast<JsonStringElement*>(aws_settings_map[kDeviceCertPathKey]);
     JsonStringElement* private_key_path_element = static_cast<JsonStringElement*>(aws_settings_map[kPrivateKeyPathKey]);
-    std::string root_ca = SDCardController::ReadFileFromSDCard(kSDCardRootPath + kAwsDocsFilePath + root_ca_path_element->data);
-    std::string device_certificate = SDCardController::ReadFileFromSDCard(kSDCardRootPath + kAwsDocsFilePath + device_cert_path_element->data);
-    std::string private_key = SDCardController::ReadFileFromSDCard(kSDCardRootPath + kAwsDocsFilePath + private_key_path_element->data);
+    std::string root_ca = sd_card_controller->ReadFileFromSDCard(kSDCardRootPath + kAwsDocsFilePath + root_ca_path_element->data);
+    std::string device_certificate = sd_card_controller->ReadFileFromSDCard(kSDCardRootPath + kAwsDocsFilePath + device_cert_path_element->data);
+    std::string private_key = sd_card_controller->ReadFileFromSDCard(kSDCardRootPath + kAwsDocsFilePath + private_key_path_element->data);
     return new AWSSettings(client_id, endpoint, port, root_ca, device_certificate, private_key, topic);
 }

--- a/M5StackThermohygrometerApp/lib/Settings/src/AWSSettings.hpp
+++ b/M5StackThermohygrometerApp/lib/Settings/src/AWSSettings.hpp
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include <SDCardController.hpp>
+
 class AWSSettings
 {
 public:
@@ -9,7 +11,7 @@ public:
 	~AWSSettings();
 
 public:
-	static AWSSettings* FromString(std::string json);
+	static AWSSettings* FromString(std::string json, SDCardController* sd_card_controller);
 
 public:
 	std::string client_id;

--- a/M5StackThermohygrometerApp/lib/Settings/src/SettingsProvider.cpp
+++ b/M5StackThermohygrometerApp/lib/Settings/src/SettingsProvider.cpp
@@ -8,27 +8,26 @@
 #include <JsonHandler.hpp>
 #include <LogConstants.hpp>
 #include <SDCardConstants.hpp>
-#include <SDCardController.hpp>
 
-AWSCommunicationSettings* SettingsProvider::Of()
+AWSCommunicationSettings* SettingsProvider::Of(SDCardController* sd_card_controller)
 {
-    return ReadAWSCommunicationSettings();
+    return ReadAWSCommunicationSettings(sd_card_controller);
 }
 
-AWSCommunicationSettings* SettingsProvider::ReadAWSCommunicationSettings()
+AWSCommunicationSettings* SettingsProvider::ReadAWSCommunicationSettings(SDCardController* sd_card_controller)
 {
-    WiFiSettings* wifi_settings = ReadWiFiSettings();
-    AWSSettings* aws_settings = ReadAWSSettings();
+    WiFiSettings* wifi_settings = ReadWiFiSettings(sd_card_controller);
+    AWSSettings* aws_settings = ReadAWSSettings(sd_card_controller);
     ConsoleLogger::Log(new LogData(LogLevel::kInfo, kSettingsProvider, kReadAWSSettings, "success"));
     return new AWSCommunicationSettings(wifi_settings, aws_settings);
 }
 
-WiFiSettings* SettingsProvider::ReadWiFiSettings()
+WiFiSettings* SettingsProvider::ReadWiFiSettings(SDCardController* sd_card_controller)
 {
     ConsoleLogger::Log(new LogData(LogLevel::kTrace, kSettingsProvider, kReadWiFiSettings, "in"));
     try
     {
-        std::string raw_wifi_settings = SDCardController::ReadFileFromSDCard(kSDCardRootPath + kWiFiSettingsFileName);
+        std::string raw_wifi_settings = sd_card_controller->ReadFileFromSDCard(kSDCardRootPath + kWiFiSettingsFileName);
         WiFiSettings* wifi_settings = WiFiSettings::FromString(raw_wifi_settings);
         ConsoleLogger::Log(new LogData(LogLevel::kDebug, kSettingsProvider, kReadWiFiSettings, "success"));
         return wifi_settings;
@@ -40,13 +39,13 @@ WiFiSettings* SettingsProvider::ReadWiFiSettings()
     return nullptr;
 }
 
-AWSSettings* SettingsProvider::ReadAWSSettings()
+AWSSettings* SettingsProvider::ReadAWSSettings(SDCardController* sd_card_controller)
 {
     ConsoleLogger::Log(new LogData(LogLevel::kTrace, kSettingsProvider, kReadAWSSettings, "in"));
     try
     {
-        std::string raw_aws_settings = SDCardController::ReadFileFromSDCard(kSDCardRootPath + kAwsDocsFilePath + kAwsSettingsFileName);
-        AWSSettings* aws_settings = AWSSettings::FromString(raw_aws_settings);
+        std::string raw_aws_settings = sd_card_controller->ReadFileFromSDCard(kSDCardRootPath + kAwsDocsFilePath + kAwsSettingsFileName);
+        AWSSettings* aws_settings = AWSSettings::FromString(raw_aws_settings, sd_card_controller);
         ConsoleLogger::Log(new LogData(LogLevel::kInfo, kSettingsProvider, kReadAWSSettings, "success"));
         return aws_settings;
     }

--- a/M5StackThermohygrometerApp/lib/Settings/src/SettingsProvider.hpp
+++ b/M5StackThermohygrometerApp/lib/Settings/src/SettingsProvider.hpp
@@ -3,13 +3,14 @@
 #include <string>
 
 #include <AWSCommunicationSettings.hpp>
+#include <SDCardController.hpp>
 
 class SettingsProvider
 {
 public:
-    static AWSCommunicationSettings* Of();
+    static AWSCommunicationSettings* Of(SDCardController* sd_card_controller);
 private:
-	static AWSCommunicationSettings* ReadAWSCommunicationSettings();
-    static WiFiSettings* ReadWiFiSettings();
-	static AWSSettings* ReadAWSSettings();
+	static AWSCommunicationSettings* ReadAWSCommunicationSettings(SDCardController* sd_card_controller);
+    static WiFiSettings* ReadWiFiSettings(SDCardController* sd_card_controller);
+	static AWSSettings* ReadAWSSettings(SDCardController* sd_card_controller);
 };

--- a/M5StackThermohygrometerApp/test/test_main.cpp
+++ b/M5StackThermohygrometerApp/test/test_main.cpp
@@ -14,6 +14,7 @@ void setup()
     run_aws_settings_tests();
     run_wifi_settings_tests();
     run_aws_communication_settings_tests();
+    run_settings_provider_tests();
 
     UNITY_END();
 }

--- a/M5StackThermohygrometerApp/test/test_main.cpp
+++ b/M5StackThermohygrometerApp/test/test_main.cpp
@@ -1,0 +1,22 @@
+#include <Arduino.h>
+#include <unity.h>
+
+#include "test_main.hpp"
+
+void setup()
+{
+    // wait for over 2 secs
+    // if board does not support software reset via Serial.DTR/RTS
+    delay(2000);
+
+    UNITY_BEGIN();
+
+    run_aws_settings_tests();
+    run_wifi_settings_tests();
+
+    UNITY_END();
+}
+
+void loop()
+{
+}

--- a/M5StackThermohygrometerApp/test/test_main.cpp
+++ b/M5StackThermohygrometerApp/test/test_main.cpp
@@ -13,6 +13,7 @@ void setup()
 
     run_aws_settings_tests();
     run_wifi_settings_tests();
+    run_aws_communication_settings_tests();
 
     UNITY_END();
 }

--- a/M5StackThermohygrometerApp/test/test_main.hpp
+++ b/M5StackThermohygrometerApp/test/test_main.hpp
@@ -3,5 +3,6 @@
 
 void run_aws_settings_tests();
 void run_wifi_settings_tests();
+void run_aws_communication_settings_tests();
 
 #endif // TEST_MAIN_HPP_

--- a/M5StackThermohygrometerApp/test/test_main.hpp
+++ b/M5StackThermohygrometerApp/test/test_main.hpp
@@ -1,0 +1,7 @@
+#ifndef TEST_MAIN_HPP_
+#define TEST_MAIN_HPP_
+
+void run_aws_settings_tests();
+void run_wifi_settings_tests();
+
+#endif // TEST_MAIN_HPP_

--- a/M5StackThermohygrometerApp/test/test_main.hpp
+++ b/M5StackThermohygrometerApp/test/test_main.hpp
@@ -1,9 +1,6 @@
 #ifndef TEST_MAIN_HPP_
 #define TEST_MAIN_HPP_
 
-void run_aws_settings_tests();
-void run_wifi_settings_tests();
-void run_aws_communication_settings_tests();
-void run_settings_provider_tests();
+#include "test_settings/test_settings.hpp"
 
 #endif // TEST_MAIN_HPP_

--- a/M5StackThermohygrometerApp/test/test_main.hpp
+++ b/M5StackThermohygrometerApp/test/test_main.hpp
@@ -4,5 +4,6 @@
 void run_aws_settings_tests();
 void run_wifi_settings_tests();
 void run_aws_communication_settings_tests();
+void run_settings_provider_tests();
 
 #endif // TEST_MAIN_HPP_

--- a/M5StackThermohygrometerApp/test/test_settings/test_aws_communication_settings.cpp
+++ b/M5StackThermohygrometerApp/test/test_settings/test_aws_communication_settings.cpp
@@ -1,0 +1,32 @@
+#include <Arduino.h>
+#include <unity.h>
+
+#include <AWSCommunicationSettings.hpp>
+#include "../test_main.hpp"
+
+void test_aws_communication_settings_ctor(void)
+{
+    WiFiSettings* wifi_settings = new WiFiSettings(
+        "ssid", "password"
+    );
+    AWSSettings* aws_settings = new AWSSettings(
+        "client_id",
+        "endpoint",
+        0,
+        "root_ca",
+        "device_certificate",
+        "private_key",
+        "topic"
+    );
+    AWSCommunicationSettings* aws_communication_settings = new AWSCommunicationSettings(
+        wifi_settings, aws_settings
+    );
+    TEST_ASSERT_NOT_NULL(aws_communication_settings);
+    TEST_ASSERT_EQUAL(wifi_settings, aws_communication_settings->wifi_settings);
+    TEST_ASSERT_EQUAL(aws_settings, aws_communication_settings->aws_settings);
+}
+
+void run_aws_communication_settings_tests()
+{
+    RUN_TEST(test_aws_communication_settings_ctor);
+}

--- a/M5StackThermohygrometerApp/test/test_settings/test_aws_communication_settings.cpp
+++ b/M5StackThermohygrometerApp/test/test_settings/test_aws_communication_settings.cpp
@@ -2,7 +2,7 @@
 #include <unity.h>
 
 #include <AWSCommunicationSettings.hpp>
-#include "../test_main.hpp"
+#include "test_settings.hpp"
 
 static void test_aws_communication_settings_ctor(void)
 {

--- a/M5StackThermohygrometerApp/test/test_settings/test_aws_communication_settings.cpp
+++ b/M5StackThermohygrometerApp/test/test_settings/test_aws_communication_settings.cpp
@@ -4,7 +4,7 @@
 #include <AWSCommunicationSettings.hpp>
 #include "../test_main.hpp"
 
-void test_aws_communication_settings_ctor(void)
+static void test_aws_communication_settings_ctor(void)
 {
     WiFiSettings* wifi_settings = new WiFiSettings(
         "ssid", "password"

--- a/M5StackThermohygrometerApp/test/test_settings/test_aws_settings.cpp
+++ b/M5StackThermohygrometerApp/test/test_settings/test_aws_settings.cpp
@@ -5,9 +5,18 @@
 
 #include "../test_main.hpp"
 #include <AWSSettings.hpp>
+#include <SDCardConstants.hpp>
 #include <SDCardController.hpp>
 
-class SDCardControllerMock : public SDCardController
+static const std::string kClientId = "client_id";
+static const std::string kEndpoint = "endpoint";
+static const int kPort = 0;
+static const std::string kRootCA = "root_ca";
+static const std::string kDeviceCert = "device_certificate";
+static const std::string kPrivateKey = "private_key";
+static const std::string kTopic = "topic";
+
+class SDCardControllerMockForAWSSettings : public SDCardController
 {
 public:
     std::string ReadFileFromSDCard(std::string file_name) override { return file_name; }
@@ -15,38 +24,34 @@ public:
 
 static void test_aws_settings_ctor(void)
 {
-	std::string client_id = "client_id";
-	std::string endpoint = "endpoint";
-	int port = 0;
-	std::string root_ca = "root_ca";
-	std::string device_certificate = "device_certificate";
-	std::string private_key = "private_key";
-	std::string topic = "topic";
-
-    AWSSettings* settings = new AWSSettings(client_id, endpoint, port, root_ca, device_certificate, private_key, topic);
-    TEST_ASSERT_EQUAL_STRING(client_id.c_str(), settings->client_id.c_str());
-    TEST_ASSERT_EQUAL_STRING(endpoint.c_str(), settings->endpoint.c_str());
-    TEST_ASSERT_EQUAL_INT32(port, settings->port);
-    TEST_ASSERT_EQUAL_STRING(root_ca.c_str(), settings->root_ca.c_str());
-    TEST_ASSERT_EQUAL_STRING(device_certificate.c_str(), settings->device_certificate.c_str());
-    TEST_ASSERT_EQUAL_STRING(private_key.c_str(), settings->private_key.c_str());
-    TEST_ASSERT_EQUAL_STRING(topic.c_str(), settings->topic.c_str());
+    AWSSettings* settings = new AWSSettings(kClientId, kEndpoint, kPort, kRootCA, kDeviceCert, kPrivateKey, kTopic);
+    TEST_ASSERT_EQUAL_STRING(kClientId.c_str(), settings->client_id.c_str());
+    TEST_ASSERT_EQUAL_STRING(kEndpoint.c_str(), settings->endpoint.c_str());
+    TEST_ASSERT_EQUAL_INT32(kPort, settings->port);
+    TEST_ASSERT_EQUAL_STRING(kRootCA.c_str(), settings->root_ca.c_str());
+    TEST_ASSERT_EQUAL_STRING(kDeviceCert.c_str(), settings->device_certificate.c_str());
+    TEST_ASSERT_EQUAL_STRING(kPrivateKey.c_str(), settings->private_key.c_str());
+    TEST_ASSERT_EQUAL_STRING(kTopic.c_str(), settings->topic.c_str());
 }
 
 static void test_aws_settings_FromString(void)
 {
-    std::string aws_settings_json("{\"clientId\":\"M5StackThermohygrometer\",\"endpoint\":\"a173nwsyyt709l-ats.iot.us-east-1.amazonaws.com\",\"port\":8883,\"rootCaPath\":\"AmazonRootCA1.pem\",\"deviceCertPath\":\"5c1d8dff120f7de45a8fb8c86c5d32656fb1f6220e3ebc273a8eb22fb1b11512-certificate.pem.crt\",\"privateKeyPath\":\"5c1d8dff120f7de45a8fb8c86c5d32656fb1f6220e3ebc273a8eb22fb1b11512-private.pem.key\",\"topic\":\"envdata\"}");
-    SDCardController* sd_card_controller_mock = new SDCardControllerMock();
+    std::string aws_settings_json
+        = "{\"clientId\":\"" + kClientId + "\",\"endpoint\":\"" + kEndpoint +
+            "\",\"port\":" + std::to_string(kPort) + ",\"rootCaPath\":\"" + kRootCA +
+            "\",\"deviceCertPath\":\"" + kDeviceCert + "\",\"privateKeyPath\":\"" + kPrivateKey +
+            "\",\"topic\":\"" + kTopic + "\"}";
+    SDCardController* sd_card_controller_mock = new SDCardControllerMockForAWSSettings();
     AWSSettings* settings = AWSSettings::FromString(aws_settings_json, sd_card_controller_mock);
     delete sd_card_controller_mock;
     TEST_ASSERT_NOT_NULL(settings);
-    TEST_ASSERT_EQUAL_STRING("M5StackThermohygrometer", settings->client_id.c_str());
-    TEST_ASSERT_EQUAL_STRING("a173nwsyyt709l-ats.iot.us-east-1.amazonaws.com", settings->endpoint.c_str());
-    TEST_ASSERT_EQUAL_INT32(8883, settings->port);
-    TEST_ASSERT_FALSE(settings->root_ca.empty());
-    TEST_ASSERT_FALSE(settings->device_certificate.empty());
-    TEST_ASSERT_FALSE(settings->private_key.empty());
-    TEST_ASSERT_EQUAL_STRING("envdata", settings->topic.c_str());
+    TEST_ASSERT_EQUAL_STRING(kClientId.c_str(), settings->client_id.c_str());
+    TEST_ASSERT_EQUAL_STRING(kEndpoint.c_str(), settings->endpoint.c_str());
+    TEST_ASSERT_EQUAL_INT32(kPort, settings->port);
+    TEST_ASSERT_EQUAL_STRING((kSDCardRootPath + kAwsDocsFilePath + kRootCA).c_str(), settings->root_ca.c_str());
+    TEST_ASSERT_EQUAL_STRING((kSDCardRootPath + kAwsDocsFilePath + kDeviceCert).c_str(), settings->device_certificate.c_str());
+    TEST_ASSERT_EQUAL_STRING((kSDCardRootPath + kAwsDocsFilePath + kPrivateKey).c_str(), settings->private_key.c_str());
+    TEST_ASSERT_EQUAL_STRING(kTopic.c_str(), settings->topic.c_str());
 }
 
 void run_aws_settings_tests()

--- a/M5StackThermohygrometerApp/test/test_settings/test_aws_settings.cpp
+++ b/M5StackThermohygrometerApp/test/test_settings/test_aws_settings.cpp
@@ -1,0 +1,56 @@
+#include <Arduino.h>
+#include <unity.h>
+
+#include <string>
+
+#include "../test_main.hpp"
+#include <AWSSettings.hpp>
+#include <SDCardController.hpp>
+
+class SDCardControllerMock : public SDCardController
+{
+public:
+    std::string ReadFileFromSDCard(std::string file_name) override { return file_name; }
+};
+
+static void test_aws_settings_ctor(void)
+{
+	std::string client_id = "client_id";
+	std::string endpoint = "endpoint";
+	int port = 0;
+	std::string root_ca = "root_ca";
+	std::string device_certificate = "device_certificate";
+	std::string private_key = "private_key";
+	std::string topic = "topic";
+
+    AWSSettings* settings = new AWSSettings(client_id, endpoint, port, root_ca, device_certificate, private_key, topic);
+    TEST_ASSERT_EQUAL_STRING(client_id.c_str(), settings->client_id.c_str());
+    TEST_ASSERT_EQUAL_STRING(endpoint.c_str(), settings->endpoint.c_str());
+    TEST_ASSERT_EQUAL_INT32(port, settings->port);
+    TEST_ASSERT_EQUAL_STRING(root_ca.c_str(), settings->root_ca.c_str());
+    TEST_ASSERT_EQUAL_STRING(device_certificate.c_str(), settings->device_certificate.c_str());
+    TEST_ASSERT_EQUAL_STRING(private_key.c_str(), settings->private_key.c_str());
+    TEST_ASSERT_EQUAL_STRING(topic.c_str(), settings->topic.c_str());
+}
+
+static void test_aws_settings_FromString(void)
+{
+    std::string aws_settings_json("{\"clientId\":\"M5StackThermohygrometer\",\"endpoint\":\"a173nwsyyt709l-ats.iot.us-east-1.amazonaws.com\",\"port\":8883,\"rootCaPath\":\"AmazonRootCA1.pem\",\"deviceCertPath\":\"5c1d8dff120f7de45a8fb8c86c5d32656fb1f6220e3ebc273a8eb22fb1b11512-certificate.pem.crt\",\"privateKeyPath\":\"5c1d8dff120f7de45a8fb8c86c5d32656fb1f6220e3ebc273a8eb22fb1b11512-private.pem.key\",\"topic\":\"envdata\"}");
+    SDCardController* sd_card_controller_mock = new SDCardControllerMock();
+    AWSSettings* settings = AWSSettings::FromString(aws_settings_json, sd_card_controller_mock);
+    delete sd_card_controller_mock;
+    TEST_ASSERT_NOT_NULL(settings);
+    TEST_ASSERT_EQUAL_STRING("M5StackThermohygrometer", settings->client_id.c_str());
+    TEST_ASSERT_EQUAL_STRING("a173nwsyyt709l-ats.iot.us-east-1.amazonaws.com", settings->endpoint.c_str());
+    TEST_ASSERT_EQUAL_INT32(8883, settings->port);
+    TEST_ASSERT_FALSE(settings->root_ca.empty());
+    TEST_ASSERT_FALSE(settings->device_certificate.empty());
+    TEST_ASSERT_FALSE(settings->private_key.empty());
+    TEST_ASSERT_EQUAL_STRING("envdata", settings->topic.c_str());
+}
+
+void run_aws_settings_tests()
+{
+    RUN_TEST(test_aws_settings_ctor);
+    RUN_TEST(test_aws_settings_FromString);
+}

--- a/M5StackThermohygrometerApp/test/test_settings/test_aws_settings.cpp
+++ b/M5StackThermohygrometerApp/test/test_settings/test_aws_settings.cpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include "../test_main.hpp"
+#include "test_settings.hpp"
 #include <AWSSettings.hpp>
 #include <SDCardConstants.hpp>
 #include <SDCardController.hpp>

--- a/M5StackThermohygrometerApp/test/test_settings/test_settings.hpp
+++ b/M5StackThermohygrometerApp/test/test_settings/test_settings.hpp
@@ -1,0 +1,9 @@
+#ifndef TEST_SETTINGS_HPP_
+#define TEST_SETTINGS_HPP_
+
+void run_aws_settings_tests();
+void run_wifi_settings_tests();
+void run_aws_communication_settings_tests();
+void run_settings_provider_tests();
+
+#endif // TEST_SETTINGS_HPP_

--- a/M5StackThermohygrometerApp/test/test_settings/test_settings_provider.cpp
+++ b/M5StackThermohygrometerApp/test/test_settings/test_settings_provider.cpp
@@ -1,0 +1,67 @@
+#include <Arduino.h>
+#include <unity.h>
+
+#include <string>
+
+#include <SDCardConstants.hpp>
+#include <SDCardController.hpp>
+#include <SettingsProvider.hpp>
+#include "../test_main.hpp"
+
+static const std::string kWiFiSettingsFile = kSDCardRootPath + kWiFiSettingsFileName;
+static const std::string kAWSSettingsFile = kSDCardRootPath + kAwsDocsFilePath + kAwsSettingsFileName;
+
+static const std::string kSsid = "hoge";
+static const std::string kPassword = "fuga";
+static const std::string kWiFiSettingsJson
+    = "{\"ssid\":\"" + kSsid + "\",\"password\":\"" + kPassword + "\"}";
+static const std::string kClientId = "hoge";
+static const std::string kEndpoint = "fuga";
+static const int kPort = 8883;
+static const std::string kRootCA = "hoge.pem";
+static const std::string kDeviceCert = "hoge-certificate.pem.crt";
+static const std::string kPrivateKey = "hoge-private.pem.key";
+static const std::string kTopic = "piyo";
+static const std::string kAWSSettingsJson
+    = "{\"clientId\":\"" + kClientId + "\",\"endpoint\":\"" + kEndpoint +
+        "\",\"port\":" + std::to_string(kPort) + ",\"rootCaPath\":\"" + kRootCA +
+        "\",\"deviceCertPath\":\"" + kDeviceCert + "\",\"privateKeyPath\":\"" + kPrivateKey +
+        "\",\"topic\":\"" + kTopic + "\"}";
+
+class SDCardControllerMockForSettingsProvider : public SDCardController
+{
+public:
+    std::string ReadFileFromSDCard(std::string file_name) override
+    {
+        if (file_name == kWiFiSettingsFile)
+        {
+            return kWiFiSettingsJson;
+        }
+        if (file_name == kAWSSettingsFile)
+        {
+            return kAWSSettingsJson;
+        }
+        return file_name;
+    }
+};
+
+static void test_settings_provider_of(void)
+{
+    SDCardController* mock = new SDCardControllerMockForSettingsProvider();
+    AWSCommunicationSettings* settings = SettingsProvider::Of(mock);
+    TEST_ASSERT_NOT_NULL(settings);
+    TEST_ASSERT_EQUAL_STRING(kSsid.c_str(), settings->wifi_settings->ssid.c_str());
+    TEST_ASSERT_EQUAL_STRING(kPassword.c_str(), settings->wifi_settings->password.c_str());
+    TEST_ASSERT_EQUAL_STRING(kClientId.c_str(), settings->aws_settings->client_id.c_str());
+    TEST_ASSERT_EQUAL_STRING(kEndpoint.c_str(), settings->aws_settings->endpoint.c_str());
+    TEST_ASSERT_EQUAL_INT32(kPort, settings->aws_settings->port);
+    TEST_ASSERT_EQUAL_STRING((kSDCardRootPath + kAwsDocsFilePath + kRootCA).c_str(), settings->aws_settings->root_ca.c_str());
+    TEST_ASSERT_EQUAL_STRING((kSDCardRootPath + kAwsDocsFilePath + kDeviceCert).c_str(), settings->aws_settings->device_certificate.c_str());
+    TEST_ASSERT_EQUAL_STRING((kSDCardRootPath + kAwsDocsFilePath + kPrivateKey).c_str(), settings->aws_settings->private_key.c_str());
+    TEST_ASSERT_EQUAL_STRING(kTopic.c_str(), settings->aws_settings->topic.c_str());
+}
+
+void run_settings_provider_tests()
+{
+    RUN_TEST(test_settings_provider_of);
+}

--- a/M5StackThermohygrometerApp/test/test_settings/test_settings_provider.cpp
+++ b/M5StackThermohygrometerApp/test/test_settings/test_settings_provider.cpp
@@ -3,10 +3,10 @@
 
 #include <string>
 
+#include "test_settings.hpp"
 #include <SDCardConstants.hpp>
 #include <SDCardController.hpp>
 #include <SettingsProvider.hpp>
-#include "../test_main.hpp"
 
 static const std::string kWiFiSettingsFile = kSDCardRootPath + kWiFiSettingsFileName;
 static const std::string kAWSSettingsFile = kSDCardRootPath + kAwsDocsFilePath + kAwsSettingsFileName;

--- a/M5StackThermohygrometerApp/test/test_settings/test_wifi_settings.cpp
+++ b/M5StackThermohygrometerApp/test/test_settings/test_wifi_settings.cpp
@@ -3,9 +3,10 @@
 
 #include <string>
 
+#include "../test_main.hpp"
 #include <WiFiSettings.hpp>
 
-void test_ctor(void)
+static void test_wifi_settings_ctor(void)
 {
     std::string ssid("hoge");
     std::string password("fuga");
@@ -14,7 +15,7 @@ void test_ctor(void)
     TEST_ASSERT_EQUAL_STRING(password.c_str(), settings->password.c_str());
 }
 
-void test_FromString(void)
+static void test_wifi_settings_FromString(void)
 {
     std::string ssid("hoge");
     std::string password("fuga");
@@ -24,20 +25,8 @@ void test_FromString(void)
     TEST_ASSERT_EQUAL_STRING(password.c_str(), settings->password.c_str());
 }
 
-void setup()
+void run_wifi_settings_tests()
 {
-    // wait for over 2 secs
-    // if board does not support software reset via Serial.DTR/RTS
-    delay(2000);
-
-    UNITY_BEGIN();
-
-    RUN_TEST(test_ctor);
-    RUN_TEST(test_FromString);
-
-    UNITY_END();
-}
-
-void loop()
-{
+    RUN_TEST(test_wifi_settings_ctor);
+    RUN_TEST(test_wifi_settings_FromString);
 }

--- a/M5StackThermohygrometerApp/test/test_settings/test_wifi_settings.cpp
+++ b/M5StackThermohygrometerApp/test/test_settings/test_wifi_settings.cpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include "../test_main.hpp"
+#include "test_settings.hpp"
 #include <WiFiSettings.hpp>
 
 static void test_wifi_settings_ctor(void)

--- a/M5StackThermohygrometerApp/test/test_settings/test_wifi_settings.cpp
+++ b/M5StackThermohygrometerApp/test/test_settings/test_wifi_settings.cpp
@@ -1,0 +1,43 @@
+#include <Arduino.h>
+#include <unity.h>
+
+#include <string>
+
+#include <WiFiSettings.hpp>
+
+void test_ctor(void)
+{
+    std::string ssid("hoge");
+    std::string password("fuga");
+    WiFiSettings* settings = new WiFiSettings(ssid, password);
+    TEST_ASSERT_EQUAL_STRING(ssid.c_str(), settings->ssid.c_str());
+    TEST_ASSERT_EQUAL_STRING(password.c_str(), settings->password.c_str());
+}
+
+void test_FromString(void)
+{
+    std::string ssid("hoge");
+    std::string password("fuga");
+    std::string wifi_settings_json("{\"ssid\":\"hoge\",\"password\":\"fuga\"}");
+    WiFiSettings* settings = WiFiSettings::FromString(wifi_settings_json);
+    TEST_ASSERT_EQUAL_STRING(ssid.c_str(), settings->ssid.c_str());
+    TEST_ASSERT_EQUAL_STRING(password.c_str(), settings->password.c_str());
+}
+
+void setup()
+{
+    // wait for over 2 secs
+    // if board does not support software reset via Serial.DTR/RTS
+    delay(2000);
+
+    UNITY_BEGIN();
+
+    RUN_TEST(test_ctor);
+    RUN_TEST(test_FromString);
+
+    UNITY_END();
+}
+
+void loop()
+{
+}


### PR DESCRIPTION
Settingsライブラリ内のクラスを対象に単体テストのコードを追加。
今後はtest/lib/lib.hpp内にテスト用関数の宣言を書くことで公開し、そのヘッダファイルをtest_main.hppで読み込むことでテストを複数階層に分割して書くようにする。
SDCardControllerは密結合で単体テストができない状態だったため、公開されている関数を抽象化することでモッククラスを作成できるように修正した。
テスト結果はすべて正常のため、このままマージする。